### PR TITLE
Fix trigger expression for size

### DIFF
--- a/Template App BackupPC by Zabbix agent.xml
+++ b/Template App BackupPC by Zabbix agent.xml
@@ -13,7 +13,7 @@
             <name>Template App BackupPC by Zabbix agent</name>
             <description>The template to monitor BackupPC metrics API by Zabbix agent without need for extra scripts on server.&#13;
 &#13;
-Template Version v0.0.1 - Evren Yurtesen&#13;
+Template Version v0.0.2 - Evren Yurtesen&#13;
 Tested on Zabbix5 and BackupPC 4.4.1 (needs updated metrics)</description>
             <groups>
                 <group>


### PR DESCRIPTION
With these small changes, it is possible to modify the threshold for warning and critial size on a per host basis. Without these, a modified size per host is only reflected in the event description but not in the expression.

And to not forget: Thank you very much for this template! Thoughtfully designed from my perspective.