### PR TITLE
Add url param format=json to omit warning

### DIFF
--- a/Template App BackupPC by Zabbix agent.xml
+++ b/Template App BackupPC by Zabbix agent.xml
@@ -51,7 +51,7 @@ Tested on Zabbix5 and BackupPC 4.4.1 (needs updated metrics)</description>
                         </step>
                     </preprocessing>
                     <master_item>
-                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                     </master_item>
                 </item>
                 <item>
@@ -76,7 +76,7 @@ Tested on Zabbix5 and BackupPC 4.4.1 (needs updated metrics)</description>
                         </step>
                     </preprocessing>
                     <master_item>
-                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                     </master_item>
                 </item>
                 <item>
@@ -120,7 +120,7 @@ function getLastBackupData(hostArray) {
                         </step>
                     </preprocessing>
                     <master_item>
-                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                     </master_item>
                 </item>
                 <item>
@@ -146,7 +146,7 @@ function getLastBackupData(hostArray) {
                         </step>
                     </preprocessing>
                     <master_item>
-                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                     </master_item>
                 </item>
                 <item>
@@ -172,12 +172,12 @@ function getLastBackupData(hostArray) {
                         </step>
                     </preprocessing>
                     <master_item>
-                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                     </master_item>
                 </item>
                 <item>
                     <name>BackupPC get metrics</name>
-                    <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                    <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                     <delay>5m</delay>
                     <history>0</history>
                     <trends>0</trends>
@@ -227,7 +227,7 @@ function getLastBackupData(hostArray) {
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -253,7 +253,7 @@ function getLastBackupData(hostArray) {
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -279,7 +279,7 @@ function getLastBackupData(hostArray) {
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -304,7 +304,7 @@ function getLastBackupData(hostArray) {
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -343,7 +343,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -368,7 +368,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -393,7 +393,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -418,7 +418,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -444,7 +444,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -469,7 +469,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -495,7 +495,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -520,7 +520,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -545,7 +545,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -570,7 +570,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -695,7 +695,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                         <item_prototype>
@@ -721,7 +721,7 @@ return sum;</params>
                                 </step>
                             </preprocessing>
                             <master_item>
-                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                                <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                             </master_item>
                         </item_prototype>
                     </item_prototypes>
@@ -801,7 +801,7 @@ Warning size per backup server or per backup host can be adjusted.</description>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <master_item>
-                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics]</key>
+                        <key>web.page.get[{$BACKUPPC.SCHEME}://{$BACKUPPC.USERNAME}:{$BACKUPPC.PASSWORD}@{$BACKUPPC.HOST}:{$BACKUPPC.PORT}/{$BACKUPPC.PATH}?action=metrics&amp;format=json]</key>
                     </master_item>
                     <preprocessing>
                         <step>


### PR DESCRIPTION
With this I don't get the following warning in BackupPC anymore:
```
backuppc  | [Tue Aug  6 07:26:59 2024] BackupPC_Admin: Use of uninitialized value $format in string eq at /usr/local/BackupPC/lib/BackupPC/CGI/Metrics.pm line 197.
backuppc  | [Tue Aug  6 07:26:59 2024] BackupPC_Admin: Use of uninitialized value $format in string eq at /usr/local/BackupPC/lib/BackupPC/CGI/Metrics.pm line 255.
```